### PR TITLE
Add traffic sign neural network example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# moin
+# Traffic Sign Neural Network
+
+This project contains a simple convolutional neural network for classifying German traffic signs (GTSRB) and applying the model to a video feed.
+
+## Training
+
+```bash
+python -m traffic_sign.train --data-root ./data --epochs 5 --lr 0.001 --batch-size 64 --device cpu --save-path model.pth
+```
+
+The script downloads the GTSRB dataset automatically and saves the model weights to `model.pth`.
+
+## Video Classification
+
+```bash
+python -m traffic_sign.predict <video_source> model.pth
+```
+
+`<video_source>` can be a path to a video file or a webcam index (e.g., `0`). Press `q` to quit the window.

--- a/traffic_sign/__init__.py
+++ b/traffic_sign/__init__.py
@@ -1,0 +1,2 @@
+from .model import TrafficSignNet
+from .dataset import load_gtsrb

--- a/traffic_sign/dataset.py
+++ b/traffic_sign/dataset.py
@@ -1,0 +1,13 @@
+import os
+from torchvision import datasets, transforms
+
+def load_gtsrb(root: str = "./data"):
+    """Load the GTSRB dataset with standard transformations."""
+    transform = transforms.Compose([
+        transforms.Resize((32, 32)),
+        transforms.ToTensor(),
+        transforms.Normalize((0.5,), (0.5,)),
+    ])
+    train_set = datasets.GTSRB(root, split="train", download=True, transform=transform)
+    test_set = datasets.GTSRB(root, split="test", download=True, transform=transform)
+    return train_set, test_set

--- a/traffic_sign/model.py
+++ b/traffic_sign/model.py
@@ -1,0 +1,26 @@
+import torch
+from torch import nn
+
+class TrafficSignNet(nn.Module):
+    """Simple CNN for traffic sign classification."""
+
+    def __init__(self, num_classes: int = 43):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 32, kernel_size=5, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, 64, kernel_size=5, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(64 * 8 * 8, 256),
+            nn.ReLU(inplace=True),
+            nn.Linear(256, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        return self.classifier(x)

--- a/traffic_sign/predict.py
+++ b/traffic_sign/predict.py
@@ -1,0 +1,52 @@
+import argparse
+
+import cv2
+import torch
+from torchvision import transforms
+
+from .model import TrafficSignNet
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Classify traffic signs in a video feed")
+    parser.add_argument("video", help="Path to video file or camera index")
+    parser.add_argument("model", help="Path to trained model")
+    parser.add_argument("--device", default="cpu")
+    args = parser.parse_args()
+
+    device = args.device
+    model = TrafficSignNet()
+    model.load_state_dict(torch.load(args.model, map_location=device))
+    model.to(device)
+    model.eval()
+
+    transform = transforms.Compose([
+        transforms.Resize((32, 32)),
+        transforms.ToTensor(),
+        transforms.Normalize((0.5,), (0.5,)),
+    ])
+
+    cap = cv2.VideoCapture(int(args.video) if args.video.isdigit() else args.video)
+    if not cap.isOpened():
+        raise RuntimeError("Could not open video")
+
+    with torch.no_grad():
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            img = transforms.functional.to_pil_image(img)
+            img = transform(img).unsqueeze(0).to(device)
+            output = model(img)
+            pred = output.argmax(1).item()
+            cv2.putText(frame, f"Pred: {pred}", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+            cv2.imshow("Traffic Sign", frame)
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/traffic_sign/train.py
+++ b/traffic_sign/train.py
@@ -1,0 +1,52 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+from .dataset import load_gtsrb
+from .model import TrafficSignNet
+
+
+def train_model(data_root: str, epochs: int, lr: float, batch_size: int, device: str, save_path: str):
+    train_set, test_set = load_gtsrb(data_root)
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_set, batch_size=batch_size)
+
+    model = TrafficSignNet(num_classes=len(train_set.classes)).to(device)
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    for epoch in range(1, epochs + 1):
+        model.train()
+        running_loss = 0.0
+        for images, labels in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+        print(f"Epoch {epoch}, Loss: {running_loss / len(train_loader):.4f}")
+
+    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), save_path)
+    print(f"Model saved to {save_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train Traffic Sign Network")
+    parser.add_argument("--data-root", default="./data", help="Dataset path")
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--lr", type=float, default=0.001)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--save-path", default="./model.pth")
+    args = parser.parse_args()
+    train_model(**vars(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add traffic sign CNN model and dataset loader
- add training script and video feed prediction script
- update README with usage instructions

## Testing
- `python -m py_compile traffic_sign/*.py`
- `python -m traffic_sign.train --help`
- `python -m traffic_sign.predict --help`


------
https://chatgpt.com/codex/tasks/task_e_6841f4b3a2048324984169b6b1d063d9