### PR TITLE
Improve traffic sign CNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Traffic Sign Neural Network
 
-This project contains a simple convolutional neural network for classifying German traffic signs (GTSRB) and applying the model to a video feed.
+This project contains a convolutional neural network for classifying German traffic signs (GTSRB) and applying the model to a video feed. The network now includes additional convolutional layers, batch normalization and dropout for improved accuracy.
 
 ## Training
 

--- a/traffic_sign/model.py
+++ b/traffic_sign/model.py
@@ -2,23 +2,34 @@ import torch
 from torch import nn
 
 class TrafficSignNet(nn.Module):
-    """Simple CNN for traffic sign classification."""
+    """Improved CNN for traffic sign classification."""
 
     def __init__(self, num_classes: int = 43):
         super().__init__()
         self.features = nn.Sequential(
-            nn.Conv2d(3, 32, kernel_size=5, padding=2),
+            nn.Conv2d(3, 32, kernel_size=3, padding=1),
+            nn.BatchNorm2d(32),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.BatchNorm2d(64),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(2),
-            nn.Conv2d(32, 64, kernel_size=5, padding=2),
+            nn.Dropout2d(0.25),
+            nn.Conv2d(64, 128, kernel_size=3, padding=1),
+            nn.BatchNorm2d(128),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(128, 128, kernel_size=3, padding=1),
+            nn.BatchNorm2d(128),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(2),
+            nn.Dropout2d(0.25),
         )
         self.classifier = nn.Sequential(
             nn.Flatten(),
-            nn.Linear(64 * 8 * 8, 256),
+            nn.Linear(128 * 8 * 8, 512),
             nn.ReLU(inplace=True),
-            nn.Linear(256, num_classes),
+            nn.Dropout(0.5),
+            nn.Linear(512, num_classes),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- implement a deeper CNN with batch norm and dropout for traffic sign classification
- mention the improved architecture in the README

## Testing
- `python -m traffic_sign.train --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python -m traffic_sign.predict --help` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6847310fe8188324be26f28a5e96fc1c